### PR TITLE
gramps returns function

### DIFF
--- a/src/dev/app.js
+++ b/src/dev/app.js
@@ -11,19 +11,13 @@ const enableMockData =
 
 app.use(bodyParser.json());
 
-app.all(
-  '/graphql',
-  graphqlExpress(req => {
-    const args = gramps({
-      dataSources: [],
-      enableMockData,
-      extraContext: req => ({ req }),
-      req,
-    });
+const getGrampsContext = gramps({
+  dataSources: [],
+  enableMockData,
+  extraContext: req => ({ req }),
+});
 
-    return args;
-  }),
-);
+app.all('/graphql', graphqlExpress(getGrampsContext));
 
 app.get(
   '/graphiql',

--- a/test/gramps.test.js
+++ b/test/gramps.test.js
@@ -13,7 +13,7 @@ describe('GrAMPS', () => {
         { namespace: 'Baz', model: req => ({ baz: 'test' }) },
       ];
 
-      const grampsConfig = gramps({ dataSources });
+      const grampsConfig = gramps({ dataSources })();
 
       expect(grampsConfig.context).toEqual({
         Foo: {
@@ -31,7 +31,7 @@ describe('GrAMPS', () => {
     it('properly adds extra context', () => {
       const grampsConfig = gramps({
         extraContext: () => ({ extra: 'test' }),
-      });
+      })();
 
       expect(grampsConfig.context).toEqual({
         extra: 'test',


### PR DESCRIPTION
Changes
```javascript
gramps({dataSources}) => ({schema, context});
```
Into
```javascript
gramps({dataSources}) => req => ({schema, context});
```

This way all of the heavy lifting of combining schemas is done **ONCE** instead of re-combining on every query. `schema` is wrapped in a closure and only `context` is recalculated on every query (as it needs to be)