### PR TITLE
allow executable schema from data source

### DIFF
--- a/src/gramps.js
+++ b/src/gramps.js
@@ -24,9 +24,8 @@ const getDefaultApolloOptions = options => ({
   ...options,
 });
 
-
 const getExecutableSchema = (source, options) => {
-  const {schema, typeDefs, resolvers, namespace} = source;
+  const { schema, typeDefs, resolvers, namespace } = source;
   if (schema instanceof GraphQLSchema) {
     return schema;
   } else if (typeof schema === 'string' || typeof typeDefs === 'string') {
@@ -38,7 +37,7 @@ const getExecutableSchema = (source, options) => {
   } else {
     return null;
   }
-}
+};
 /**
 * Maps data sources and returns array of executable schema
 * @param  {Array}   sources  data sources to combine
@@ -48,7 +47,7 @@ const getExecutableSchema = (source, options) => {
 */
 const mapSourcesToExecutableSchemas = (sources, mock, options) =>
   sources
-    .map((source) => {
+    .map(source => {
       const { schema, typeDefs, resolvers, mocks } = source;
       const executableSchema = getExecutableSchema(source, options);
 

--- a/src/gramps.js
+++ b/src/gramps.js
@@ -24,6 +24,21 @@ const getDefaultApolloOptions = options => ({
   ...options,
 });
 
+
+const getExecutableSchema = (source, options) => {
+  const {schema, typeDefs, resolvers, namespace} = source;
+  if (schema instanceof GraphQLSchema) {
+    return schema;
+  } else if (typeof schema === 'string' || typeof typeDefs === 'string') {
+    return makeExecutableSchema({
+      typeDefs: typeDefs || schema,
+      resolvers: mapResolvers(namespace, resolvers),
+      ...options.makeExecutableSchema,
+    });
+  } else {
+    return null;
+  }
+}
 /**
 * Maps data sources and returns array of executable schema
 * @param  {Array}   sources  data sources to combine
@@ -33,20 +48,11 @@ const getDefaultApolloOptions = options => ({
 */
 const mapSourcesToExecutableSchemas = (sources, mock, options) =>
   sources
-    .map(({ schema, typeDefs, resolvers, mocks, namespace }) => {
-      let executableSchema;
-      if (schema instanceof GraphQLSchema) {
-        executableSchema = schema;
-      } else if (typeof schema === 'string' || typeof typeDefs === 'string') {
-        executableSchema = makeExecutableSchema({
-          typeDefs: typeDefs || schema,
-          resolvers: mapResolvers(namespace, resolvers),
-          ...options.makeExecutableSchema,
-        });
-      } else {
-        return null;
-      }
-      if (mock) {
+    .map((source) => {
+      const { schema, typeDefs, resolvers, mocks } = source;
+      const executableSchema = getExecutableSchema(source, options);
+
+      if (executableSchema && mock) {
         addMockFunctionsToSchema({
           schema: executableSchema,
           mocks,

--- a/src/gramps.js
+++ b/src/gramps.js
@@ -33,23 +33,27 @@ const getDefaultApolloOptions = options => ({
 */
 const mapSourcesToExecutableSchemas = (sources, mock, options) =>
   sources
-    .map(({ schema: typeDefs, resolvers, mocks, namespace }) => {
-      if (!typeDefs) {
+    .map(({ schema, typeDefs, resolvers, mocks, namespace }) => {
+      let executableSchema;
+      if (schema instanceof GraphQLSchema) {
+        executableSchema = schema;
+      } else if (typeof schema === 'string' || typeof typeDefs == 'string'){
+        executableSchema = makeExecutableSchema({
+          typeDefs: typeDefs || schema,
+          resolvers: mapResolvers(namespace, resolvers),
+          ...options.makeExecutableSchema,
+        });
+      } else {
         return null;
       }
-      const schema = makeExecutableSchema({
-        typeDefs,
-        resolvers: mapResolvers(namespace, resolvers),
-        ...options.makeExecutableSchema,
-      });
       if (mock) {
         addMockFunctionsToSchema({
-          schema,
+          schema: executableSchema,
           mocks,
           ...options.addMockFunctionsToSchema,
         });
       }
-      return schema;
+      return executableSchema;
     })
     .filter(schema => schema instanceof GraphQLSchema);
 

--- a/src/gramps.js
+++ b/src/gramps.js
@@ -37,7 +37,7 @@ const mapSourcesToExecutableSchemas = (sources, mock, options) =>
       let executableSchema;
       if (schema instanceof GraphQLSchema) {
         executableSchema = schema;
-      } else if (typeof schema === 'string' || typeof typeDefs == 'string'){
+      } else if (typeof schema === 'string' || typeof typeDefs === 'string') {
         executableSchema = makeExecutableSchema({
           typeDefs: typeDefs || schema,
           resolvers: mapResolvers(namespace, resolvers),

--- a/test/gramps.test.js
+++ b/test/gramps.test.js
@@ -1,4 +1,5 @@
 import { GraphQLSchema } from 'graphql';
+import { makeExecutableSchema } from 'graphql-tools';
 import gramps from '../src/gramps';
 
 describe('GrAMPS', () => {
@@ -22,6 +23,16 @@ describe('GrAMPS', () => {
       const dataSources = [
         { namespace: 'Foo', model: { foo: 'test' } },
         { namespace: 'Bar', model: { bar: 'test' } },
+        {
+          schema: makeExecutableSchema({
+            typeDefs: 'type Query { me: String }',
+            resolvers: {
+              Query: {
+                me: () => 'test name',
+              },
+            },
+          }),
+        },
         {
           namespace: 'Baz',
           schema: 'type User { name: String } type Query { me: User }',


### PR DESCRIPTION
Per discussion in https://github.com/gramps-graphql/gramps-express/issues/39

A data source can either provide
```
typeDefs: String
resolvers: Object
```
or
```
schema: GraphQLSchema
```

This implementation is extremely generous, flexible enough for both the former definition of a data-source and the new at the same time.