### PR TITLE
docs: add js.org domain and start error docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **An easier way to manage the data sources powering your GraphQL server.**
 
-**GrAMPS** (short for **Gr**aphQL **A**pollo **M**icroservice **P**attern **S**erver) is middleware designed for [apollo-server-express](https://git.io/vd1wc) that allows independent data sources — a schema, resolvers, and data access model — to be composed into a single GraphQL schema, while keeping the code within each data source isolated, independently testable, and completely decoupled from the rest of your application.
+**GrAMPS** (short for **Gr**aphQL **A**pollo **M**icroservice **P**attern **S**erver) is a thin layer of helper tools designed for the [Apollo GraphQL server](https://github.com/apollographql/apollo-server/) that allows independent data sources — a schema, resolvers, and data access model — to be composed into a single GraphQL schema, while keeping the code within each data source isolated, independently testable, and completely decoupled from the rest of your application.
 
 ## Developer Quickstart
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+gramps.js.org

--- a/docs/_content/errors/GrampsError.md
+++ b/docs/_content/errors/GrampsError.md
@@ -1,0 +1,5 @@
+---
+title: GrampsError
+---
+
+TKTK

--- a/docs/_content/errors/formatError.md
+++ b/docs/_content/errors/formatError.md
@@ -1,0 +1,58 @@
+---
+title: Format GraphQL Errors With Helpful Data
+---
+
+Figuring out where errors are coming from — and what to do about them — can be tricky in GraphQL. It’s especially tricky when something goes wrong on the client side to figure out exactly where it went wrong on the server.
+
+To improve the error handling process, GrAMPS offers a `formatError` function that can be passed in the [`GraphQLOptions` object](https://www.apollographql.com/docs/apollo-server/setup.html#graphqlOptions) for an Apollo server.
+
+## Installation and Setup
+
+To install:
+
+```sh
+yarn add @gramps/errors
+```
+
+To use with your Apollo server:
+
+```js
+import { formatError } from '@gramps/errors';
+
+// If no logger is supplied, `console` will be used.
+import logger from './custom-logger';
+
+const GraphQLOptions = {
+  schema: /* your GraphQL schema */,
+  formatError: formatError(logger),
+};
+
+// Assumes an Express server
+app.use('/graphql', graphqlExpress(GraphQLOptions));
+```
+
+## Example Production Client-Side Output
+
+This is an example of server side errors taken from the [xkcd data source](https://github.com/gramps-graphql/data-source-xkcd):
+
+```
+
+```
+
+**NOTE:** In development, the `targetEndpoint` and `docsLink` properties are passed to the client.
+
+## Example Server-Side Output
+
+This is an example of server side errors taken from the [xkcd data source](https://github.com/gramps-graphql/data-source-xkcd):
+
+```
+Error: Could not load the given xkcd comic (178460c1-c8d7-42c2-ba0e-f617afb5d3fd)
+Description: Could not load the given xkcd comic
+Error Code: XKCDModel_Error
+GraphQL Model: XKCDModel
+Target Endpoint: https://xkcd.com/2000/info.0.json
+Documentation: https://ibm.biz/gramps-data-source-tutorial
+Data: {
+    "id": "2000"
+}
+```


### PR DESCRIPTION
- Add a `CNAME` so we can use gramps.js.org
- Start the docs for `@gramps/errors`
