### PR TITLE
docs: use relative paths to avoid HTTP/HTTPS issue

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -5,17 +5,17 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <title>{{ site.title }}</title>
-  <link rel="apple-touch-icon" sizes="180x180" href="{{ site.github.url }}/assets/img/favicon/apple-touch-icon.png?v2">
-  <link rel="icon" type="image/png" sizes="32x32" href="{{ site.github.url }}/assets/img/favicon/favicon-32x32.png?v2">
-  <link rel="icon" type="image/png" sizes="16x16" href="{{ site.github.url }}/assets/img/favicon/favicon-16x16.png?v2">
-  <link rel="manifest" href="{{ site.github.url }}/assets/img/favicon/manifest.json">
-  <link rel="mask-icon" href="{{ site.github.url }}/assets/img/favicon/safari-pinned-tab.svg?v2" color="#e10098">
-  <link rel="shortcut icon" href="{{ site.github.url }}/assets/img/favicon/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href='{{ "/assets/img/favicon/apple-touch-icon.png?v2" | relative_url }}'>
+  <link rel="icon" type="image/png" sizes="32x32" href='{{ "/assets/img/favicon/favicon-32x32.png?v2" | relative_url }}'>
+  <link rel="icon" type="image/png" sizes="16x16" href='{{ "/assets/img/favicon/favicon-16x16.png?v2" | relative_url }}'>
+  <link rel="manifest" href='{{ "/assets/img/favicon/manifest.json" | relative_url }}'>
+  <link rel="mask-icon" href='{{ "/assets/img/favicon/safari-pinned-tab.svg?v2" | relative_url }}' color="#e10098">
+  <link rel="shortcut icon" href='{{ "/assets/img/favicon/favicon.ico?v2" | relative_url }}'>
   <meta name="apple-mobile-web-app-title" content="GrAMPS">
   <meta name="application-name" content="GrAMPS">
-  <meta name="msapplication-config" content="{{ site.github.url }}/assets/img/favicon/browserconfig.xml">
+  <meta name="msapplication-config" content='{{ "/assets/img/favicon/browserconfig.xml" | relative_url }}'>
   <meta name="theme-color" content="#ffffff">
-  <link rel="stylesheet" href="{{ site.github.url }}/assets/css/main.css"></link>
+  <link rel="stylesheet" href='{{ "/assets/css/main.css" | relative_url }}'></link>
 </head>
 
 <body>


### PR DESCRIPTION
I got https://gramps.js.org set up, but the paths are all absolute and using http:// — which means it looks like garbage. :)

This _should_ fix it, according to the Jekyll docs.