### PR TITLE
Make `mapResolvers` a pure function

### DIFF
--- a/src/lib/mapResolvers.js
+++ b/src/lib/mapResolvers.js
@@ -1,28 +1,25 @@
-import merge from 'lodash.merge';
+const mapObj = fn => obj =>
+  Object.keys(obj).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(obj[key], key, obj) }),
+    {},
+  );
+
+const checkFn = (fn, fieldName) => {
+  if (typeof fn !== 'function') {
+    throw new Error(
+      `Expected Function for ${fieldName} resolver but received ${typeof fn}`,
+    );
+  }
+};
+
+const wrapFn = namespace => (fn, fieldName) => {
+  checkFn(fn, fieldName);
+  return (root, args, context, info) =>
+    fn(root, args, context[namespace], info);
+};
 
 export default (namespace, resolvers) => {
   if (resolvers instanceof Object) {
-    return Object.keys(resolvers).reduce((newResolvers, type) => {
-      const fieldResolvers = Object.keys(resolvers[type]).map(field => {
-        const fn = resolvers[type][field];
-
-        if (typeof fn !== 'function') {
-          throw new Error(
-            `Expected Function for ${type}.${field} resolver but received ${typeof fn}`,
-          );
-        }
-
-        const resolver = (root, args, context, info) =>
-          fn(root, args, context[namespace], info);
-
-        return {
-          [type]: {
-            [field]: resolver,
-          },
-        };
-      });
-
-      return merge(newResolvers, ...fieldResolvers);
-    }, {});
+    return mapObj(mapObj(wrapFn(namespace)))(resolvers);
   }
 };


### PR DESCRIPTION
@jlengstorf Slightly different behavior from originally (like only the `fieldResolvers` are returned), so let me know if you want me to update anything (like passing in `resolvers` to `.reduce()` and doing `merge({}, resolvers, newResolver)` instead)

- Closes #23