### PR TITLE
mapResolvers only maps object literals

### DIFF
--- a/src/lib/mapResolvers.js
+++ b/src/lib/mapResolvers.js
@@ -1,8 +1,13 @@
-const mapObj = fn => obj =>
-  Object.keys(obj).reduce(
-    (acc, key) => ({ ...acc, [key]: fn(obj[key], key, obj) }),
-    {},
-  );
+const mapObj = fn => obj => {
+  if (obj.constructor.name === 'Object') {
+    return Object.keys(obj).reduce(
+      (acc, key) => ({ ...acc, [key]: fn(obj[key], key, obj) }),
+      {},
+    );
+  } else {
+    return obj;
+  }
+};
 
 const checkFn = (fn, fieldName) => {
   if (typeof fn !== 'function') {

--- a/test/lib/mapResolvers.test.js
+++ b/test/lib/mapResolvers.test.js
@@ -1,3 +1,4 @@
+import { GraphQLScalarType } from 'graphql';
 import mapResolvers from '../../src/lib/mapResolvers';
 
 describe('lib/mapResolvers', () => {
@@ -25,5 +26,15 @@ describe('lib/mapResolvers', () => {
         },
       });
     }).toThrow();
+  });
+
+  it('passes scalar types through untouched', () => {
+    const resolvers = {
+      json: new GraphQLScalarType({
+        name: 'json',
+        serialize: () => 'this is fake json',
+      }),
+    };
+    expect(mapResolvers('namespace', resolvers).json).toEqual(resolvers.json);
   });
 });


### PR DESCRIPTION
addresses #41 

`mapResolvers` should only map when an object literal is passed in. Otherwise it leaves the original object as is.