### PR TITLE
Support `Subscription` resolvers

### DIFF
--- a/src/lib/mapResolvers.js
+++ b/src/lib/mapResolvers.js
@@ -1,10 +1,14 @@
 const omit = key => ['Subscription'].includes(key);
+
+const maybeMap = (key, fn, obj) =>
+  omit(key) ? obj[key] : fn(obj[key], key, obj);
+
 const mapObj = fn => obj => {
   if (obj.constructor.name === 'Object') {
     return Object.keys(obj).reduce(
       (acc, key) => ({
         ...acc,
-        [key]: omit(key) ? obj[key] : fn(obj[key], key, obj),
+        [key]: maybeMap(key, fn, obj),
       }),
       {},
     );

--- a/src/lib/mapResolvers.js
+++ b/src/lib/mapResolvers.js
@@ -1,7 +1,11 @@
+const omit = key => ['Subscription'].includes(key);
 const mapObj = fn => obj => {
   if (obj.constructor.name === 'Object') {
     return Object.keys(obj).reduce(
-      (acc, key) => ({ ...acc, [key]: fn(obj[key], key, obj) }),
+      (acc, key) => ({
+        ...acc,
+        [key]: omit(key) ? obj[key] : fn(obj[key], key, obj),
+      }),
       {},
     );
   } else {

--- a/test/lib/mapResolvers.test.js
+++ b/test/lib/mapResolvers.test.js
@@ -37,4 +37,12 @@ describe('lib/mapResolvers', () => {
     };
     expect(mapResolvers('namespace', resolvers).json).toEqual(resolvers.json);
   });
+  it('does not map Subscription resolvers', () => {
+    const resolvers = {
+      Subscription: {
+        subscribe: () => 'foobar',
+      },
+    };
+    expect(mapResolvers('namespace', resolvers)).toEqual(resolvers);
+  });
 });


### PR DESCRIPTION
https://www.apollographql.com/docs/graphql-subscriptions/subscriptions-to-schema.html#subscription-server

Subscription field resolvers are not function but rather Objects with `resolve` and `subscribe` fields. This PR prevents mapping `Subscription` resolvers altogether.

fixes #58 