### PR TITLE
Preserve Type Resolvers When Merging Schemas

### DIFF
--- a/src/gramps.js
+++ b/src/gramps.js
@@ -130,7 +130,7 @@ export default function gramps(
   const linkTypeDefs = sourcesWithStitching.map(
     source => source.stitching.linkTypeDefs,
   );
-  const resolvers = combineStitchingResolvers(sourcesWithStitching);
+  const resolvers = combineStitchingResolvers(sources);
 
   const schema = mergeSchemas({
     schemas: [...schemas, ...linkTypeDefs],

--- a/src/lib/combineStitchingResolvers.js
+++ b/src/lib/combineStitchingResolvers.js
@@ -3,6 +3,11 @@ import merge from 'lodash.merge';
 export default sources => mergeInfo => {
   return merge(
     {},
-    ...sources.map(source => source.stitching.resolvers(mergeInfo)),
+    ...sources
+      .filter(source => source.stitching)
+      .map(source => source.stitching.resolvers(mergeInfo)),
+    ...sources
+      .filter(source => source.resolvers)
+      .map(source => source.resolvers),
   );
 };


### PR DESCRIPTION
**Bug:** I have two data sources, Standalone (S) and Dependant (D). D requires types from S. Currently, resolvers defined on fields in S are not being executed when that type is returned in D.
For example, suppose schema S has a type `Foo` with a field `bar`. The resolver for`bar` does NOT run if D returns a `Foo`. 

If I look up `Foo[bar]` on the `GraphQLSchema` for S after `mapSourcesToExecutableSchemas` has run ( [here](https://github.com/gramps-graphql/gramps/blob/master/src/gramps.js#L123) ) with something like...

`schemas[0].getType('Foo')._fields['bar']`

I can see that the resultant object correctly has the `resolve` property where my resolver function from S should be stored. However, immediately after `mergeSchemas` is run ( [here](https://github.com/gramps-graphql/gramps/blob/master/src/gramps.js#L135) ), the `resolve` property is missing from `schema.getType('Foo')._fields['bar']`. 

**Cause:** At the end of the day, I have to think this problem is a failure of `mergeSchemas`. If the provided "link resolvers" don't contain the top level types, the original top-level resolvers are blown out. I'm not sure if this is supposed to be a "feature," since it DOES preserve the type resolvers in question with regards to the context of the schema it was defined in. [Here is a runnable example gist.](https://gist.github.com/Piefayth/3a5d101ff34fdb822d7e3963e00edb03) Comments towards the bottom explain with example. 

**Fix:** Include all resolvers in the link resolvers. Let me know if you'd like to approach this a different way, or if you think this would break certain cases. Thanks!