### PR TITLE
Extract separate `prepare` function

### DIFF
--- a/src/gramps.js
+++ b/src/gramps.js
@@ -155,6 +155,10 @@ export function prepare(
   return {
     schema,
     context: getContext,
+    addContext: (req, res, next) => {
+      req.gramps = getContext(req);
+      next();
+    },
     // formatError: formatError(logger),
     ...apolloOptions.graphqlExpress,
   };

--- a/src/gramps.js
+++ b/src/gramps.js
@@ -100,7 +100,7 @@ const mapSourcesToExecutableSchemas = (sources, shouldMock, options) =>
  * @param  {Object?}   config.apollo          options for Apollo functions
  * @return {Function}                         req => options for `graphqlExpress()`
  */
-export default function gramps(
+export function prepare(
   {
     dataSources = [],
     enableMockData = process.env.GRAMPS_MODE === 'mock',
@@ -152,10 +152,18 @@ export default function gramps(
     }, {});
   };
 
-  return req => ({
+  return {
     schema,
-    context: getContext(req),
+    context: getContext,
     // formatError: formatError(logger),
     ...apolloOptions.graphqlExpress,
+  };
+}
+
+export default function gramps(...args) {
+  const options = prepare(...args);
+  return req => ({
+    ...options,
+    context: options.context(req),
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 import gramps from './gramps';
 
+export { prepare } from './gramps';
 export default gramps;

--- a/test/gramps.test.js
+++ b/test/gramps.test.js
@@ -1,10 +1,21 @@
 import { GraphQLSchema } from 'graphql';
 import * as GraphQLTools from 'graphql-tools';
-import gramps from '../src';
+import gramps, { prepare } from '../src';
 
 describe('GrAMPS', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('prepare()', () => {
+    it('addContext() adds gramps property to request object', () => {
+      const { addContext } = prepare();
+      const next = jest.genMockFn();
+      const req = {};
+      addContext(req, {}, next);
+      expect(req).toEqual({ gramps: {} });
+      expect(next).toBeCalled();
+    });
   });
 
   describe('gramps()', () => {


### PR DESCRIPTION
Re #62 #63 

```javascript
import {prepare} from '@gramps/gramps';

const {schema, context, addContext} = prepare(...);
// do stuff with `schema`
app.use('/graphql', addContext) // req.gramps = {...[gramps context stuff]}
```