### PR TITLE
fix: include extra context for stitching resolvers

### DIFF
--- a/src/gramps.js
+++ b/src/gramps.js
@@ -100,15 +100,13 @@ const mapSourcesToExecutableSchemas = (sources, shouldMock, options) =>
  * @param  {Object?}   config.apollo          options for Apollo functions
  * @return {Function}                         req => options for `graphqlExpress()`
  */
-export default function gramps(
-  {
-    dataSources = [],
-    enableMockData = process.env.GRAMPS_MODE === 'mock',
-    extraContext = req => ({}), // eslint-disable-line no-unused-vars
-    logger = console,
-    apollo = {},
-  } = {},
-) {
+export default function gramps({
+  dataSources = [],
+  enableMockData = process.env.GRAMPS_MODE === 'mock',
+  extraContext = req => ({}), // eslint-disable-line no-unused-vars
+  logger = console,
+  apollo = {},
+} = {}) {
   // Make sure all Apollo options are set properly to avoid undefined errors.
   const apolloOptions = getDefaultApolloOptions(apollo);
 
@@ -149,7 +147,7 @@ export default function gramps(
         ...allContext,
         [source.namespace]: { ...extra, ...sourceContext },
       };
-    }, {});
+    }, extra);
   };
 
   return req => ({

--- a/test/gramps.test.js
+++ b/test/gramps.test.js
@@ -85,6 +85,7 @@ describe('GrAMPS', () => {
 
       expect(grampsConfig.context).toEqual({
         FOO: { extra: 'context', source: 'context' },
+        extra: 'context',
       });
     });
 


### PR DESCRIPTION
Extra context is now included both _inside_ data source namespaced contexts and _at the top level_ to ensure it’s available for schema stitching.

close #68