### PR TITLE
fix: allow gramps() calls with no options

### DIFF
--- a/src/gramps.js
+++ b/src/gramps.js
@@ -164,8 +164,9 @@ export function prepare({
   };
 }
 
-export default function gramps(...args) {
-  const options = prepare(...args);
+export default function gramps(config = {}) {
+  const options = prepare(config);
+
   return req => ({
     ...options,
     context: options.context(req),


### PR DESCRIPTION
- Remove rest/spread for `gramps()` args
- Add single options object with a default

close #81, close #84