### PR TITLE
allow the passing of custom options for get calls if those options ar…

### DIFF
--- a/packages/rest-helpers/src/GraphQLConnector.js
+++ b/packages/rest-helpers/src/GraphQLConnector.js
@@ -62,6 +62,7 @@ export default class GraphQLConnector {
    * @return {object}
    */
   getRequestConfig = (uri, options = {}) => ({
+    ...options,
     uri,
     json: true,
     resolveWithFullResponse: true,


### PR DESCRIPTION
…e provided

Currently, the GraphqlConnector does not allow users to pass in custom options during get calls. This small change allows them to do so without impacting users who are calling get without providing those options.